### PR TITLE
fix(codecov): strip /v2 module prefix so the ignore list applies

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,17 @@ coverage:
       default:
         target: auto
 
+# Go's coverage profile reports every file under the full module path, which for
+# this repo includes the /v2 major-version suffix, e.g.
+#   github.com/dfns/dfns-sdk-go/v2/agreements/client.go
+# Codecov matches the repo-relative `ignore` patterns below against those paths,
+# so without stripping the module prefix none of them match: the entire generated
+# SDK gets counted as 0%-covered, dragging project coverage from ~98% (signer +
+# internal, the hand-written runtime) down to ~68% and failing project + patch on
+# every sync PR. Strip the prefix so paths are repo-relative and `ignore` applies.
+fixes:
+  - "github.com/dfns/dfns-sdk-go/v2/::"
+
 ignore:
   - "agreements/**"
   - "allocations/**"


### PR DESCRIPTION
Codecov reported every Go coverage file under the full module path (`github.com/dfns/dfns-sdk-go/v2/agreements/...`), so the repo-relative `ignore` patterns never matched. The entire generated SDK was counted as 0%-covered, dropping project coverage from ~98% (signer + internal) to ~68% and failing `codecov/project` + `codecov/patch` on every `sdk-sync` PR.

This adds a `fixes` directive to strip the module prefix so coverage paths are repo-relative and the existing `ignore` list takes effect again. No change to what is measured (still the hand-written `signer` + `internal` packages).

**Expected:** `codecov/project` on this PR should report ~98% instead of ~68%, confirming the ignore list now applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)